### PR TITLE
Add bounding box argument to write_normalise

### DIFF
--- a/private/get_default_opt.m
+++ b/private/get_default_opt.m
@@ -70,6 +70,7 @@ if ~isfield(opt.segment,'maskvol'),  opt.segment.maskvol  = 1;  end
 % Normalise options
 if ~isfield(opt,'normalise'),     opt.normalise     = struct; end
 if ~isfield(opt.normalise,'vox'), opt.normalise.vox = [];  end
+if ~isfield(opt.normalise,'bb'),  opt.normalise.bb  = [];  end
 % Path to template (good for using, e.g., VoxelMorph)
 if ~isfield(opt,'pth_template'),   opt.pth_template = []; end
 


### PR DESCRIPTION
Added a bounding box argument to the write_normalised function and the default options structure.
Also fixed the conditional code around the writing the labels in write_normalised since short circuiting did not work when testing whether numel(Nii)>1.